### PR TITLE
Update req types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mfl/req",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A module used to make a request and apply a json mask if necessary.",
   "main": "source/index.js",
   "author": "MFL Team",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "json-mask": "0.3.8"
   },
   "devDependencies": {
-    "@mfl/flow-highland": "4.1.0",
+    "@mfl/flow-highland": "4.2.0",
     "@mfl/flow-jasmine": "1.6.1",
     "@mfl/jasmine-n-matchers": "2.1.1",
     "babel-eslint": "7.2.3",
@@ -52,7 +52,7 @@
     "eslint-plugin-flowtype": "2.32.1",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-prettier": "2.0.1",
-    "flow-bin": "0.44.2",
+    "flow-bin": "0.45.0",
     "jest": "^19.0.2",
     "pre-commit": "1.2.2",
     "prettier": "1.2.2"

--- a/source/buffer-json-request.js
+++ b/source/buffer-json-request.js
@@ -29,7 +29,7 @@ import type { Response, AbortStream } from './buffer-request.js';
 import type { InputOptions } from './build-options.js';
 import type { TransportModules } from './index.js';
 
-type JsonResponse = {
+export type JsonResponse = {
   ...$Exact<Response>,
   +body: Object
 };

--- a/source/buffer-request.js
+++ b/source/buffer-request.js
@@ -37,7 +37,8 @@ import type { InputOptions } from './build-options.js';
 export type Response = {
   body: string,
   +headers: {
-    [key: string]: string
+    [key: string]: string,
+    'set-cookie': string[]
   },
   +statusCode: number
 };

--- a/source/index.js
+++ b/source/index.js
@@ -29,6 +29,9 @@ import bufferJsonRequest from './buffer-json-request.js';
 
 import type { Agent } from 'http';
 
+export type { InputOptions, Options } from './build-options.js';
+export type { JsonResponse } from './buffer-json-request.js';
+
 export type Transports = 'http' | 'https';
 
 export type TransportModules = typeof https | typeof http;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@mfl/flow-highland@4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@mfl/flow-highland/-/flow-highland-4.1.0.tgz#86856f6f34cc06fa31be21124151c3768522de4d"
+"@mfl/flow-highland@4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@mfl/flow-highland/-/flow-highland-4.2.0.tgz#100b587edb8e5e6dde6e031c53b2d0c1292903f4"
 
 "@mfl/flow-jasmine@1.6.1":
   version "1.6.1"
@@ -1349,9 +1349,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.44.2:
-  version "0.44.2"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.44.2.tgz#3893c7db5de043ed82674f327a04b1309db208b5"
+flow-bin@0.45.0:
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.45.0.tgz#009dd0f577a3f665c74ca8be827ae8c2dd8fd6b5"
 
 flow-parser@0.43.0:
   version "0.43.0"


### PR DESCRIPTION
Fixes #3.

Export req types that are useful outside the module.

Add a override where the set-cookie header is always an array of string.

Signed-off-by: Joe Grund <grundjoseph@gmail.com>