### PR TITLE
Fixes #5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@mfl/flow-highland": "^4.2.0",
     "@mfl/fp": "8.0.0",
     "highland": "3.0.0-beta.4",
     "json-mask": "0.3.8"
   },
   "devDependencies": {
-    "@mfl/flow-highland": "4.2.0",
     "@mfl/flow-jasmine": "1.6.1",
     "@mfl/jasmine-n-matchers": "2.1.1",
     "babel-eslint": "7.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@mfl/flow-highland@4.2.0":
+"@mfl/flow-highland@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@mfl/flow-highland/-/flow-highland-4.2.0.tgz#100b587edb8e5e6dde6e031c53b2d0c1292903f4"
 


### PR DESCRIPTION
Add flow-highland as a dependency instead of a dev dependency

Move flow-highland from a dev dependency to a dependency.

Signed-off-by: Will Johnson <william.c.johnson@intel.com>